### PR TITLE
Section name and title should not be the same

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+compiled/

--- a/scribblings/colors.scrbl
+++ b/scribblings/colors.scrbl
@@ -17,7 +17,7 @@
 
 @defmodule[colors]
 
-@section{Colors}
+@section{Introduction}
 
 the colors library provides alternatives to rgb color representations. it current supports hsl (hue,
 saturation, luminosity), hsi (hue, saturation, intensity), and hsv (hue, saturation, value).


### PR DESCRIPTION
This avoids the following warning:

```
WARNING: collected information for key multiple times: '(part "Colors"); values: '#(("Colors") (part "Colors") () (doc #"colors" #"index.html") #t) '#(("Colors") (part "Colors") (1) (doc #"colors" #"index.html") #f)
WARNING: collected information for key multiple times: '(index-entry (part "Colors")); values: (list '("Colors") (list (element #f '("Colors"))) (part-index-desc)) (list '("Colors") (list (element #f '("Colors"))) (part-index-desc))
```